### PR TITLE
Fixed typo in readme and removed readonly flag in docker-compose.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ mosquitto_pub -h localhost -t sensor/temperature -m 23
 
 The config file is in the file [mosquito.conf](./config/mosquitto.conf)
 
-By default we activated the log and data persistance (logs are in the `log` folder, and data are stored in a docker voume).
+By default we activated the log and data persistance (logs are in the `log` folder, and data are stored in a docker volume).
 
 ## Authentication
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   mosquitto:
     image: eclipse-mosquitto:2
     volumes:
-      - ./config/:/mosquitto/config/:ro
+      - ./config/:/mosquitto/config/
       - ./log/:/mosquitto/log/
       - data:/mosquitto/data/
     ports:


### PR DESCRIPTION
Hi and thanks for this great template. 
Found a typo in the readme and also noticed that changing the password fails because the config folder is readonly.
