### PR TITLE
Launched as non-root user (improved security)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   mosquitto:
     image: eclipse-mosquitto:2
+    user: mosquitto
     volumes:
       - ./config/:/mosquitto/config/
       - ./log/:/mosquitto/log/


### PR DESCRIPTION
Change of to mosquitto user to avoid running the container as root (improved security)