### PR TITLE
fix: changed "docker-compose" to "docker compose"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a simple [Mosquitto](https://mosquitto.org) broker to quickly initialize
 ## Prerequisite
 
 - [Docker](https://www.docker.com/)
-- [Docker compose](https://docs.docker.com/compose/) +v1.27.0 (better to have v2)
+- [Docker compose V2](https://docs.docker.com/compose/)
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a simple [Mosquitto](https://mosquitto.org) broker to quickly initialize
 To start the container, just :
 
 ```bash
-UID=$UID GID=$GID docker-compose up -d
+UID=$UID GID=$GID docker compose up -d
 ```
 
 The Mosquitto broker is now available on localhost. You can test it easily (require Mosquitto client):

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a simple [Mosquitto](https://mosquitto.org) broker to quickly initialize
 ## Prerequisite
 
 - [Docker](https://www.docker.com/)
-- [Docker compose V2](https://docs.docker.com/compose/)
+- [Docker Compose V2](https://docs.docker.com/compose/)
 
 ## How to use
 


### PR DESCRIPTION
In README.md the command to start the container uses "docker-compose". Docker suggests to start using "docker compose" instead, since the Compose V1 support ends in June/23.
Reference: https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/