### PR TITLE
fix: add r/w permissions for stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write    
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I generated from template a repository and stale action failed

When I read documentation of stale action, I found this:
![image](https://github.com/user-attachments/assets/cd670069-1a0f-490e-a520-8af71acbbf0e)
